### PR TITLE
Improve bearer auth handling

### DIFF
--- a/codegen/templates/main.js
+++ b/codegen/templates/main.js
@@ -37,19 +37,21 @@ module.exports = function SkyAPI ({origin, domain, tenant, key, secret, audience
     return json.access_token
   }
 
-  const request = async ({method, path, query, body}) => {
-    if (!token && key && secret) {
-      token = await refresh()
-    }
-
+  const request = async ({method, path, query, body, security}) => {
     let headers = {}
 
-    if (token) {
-      const {payload: {exp}} = jws.decode(token)
-      if (Date.now() >= exp * 1000) {
+    if (security) {
+      if (!token && key && secret) {
         token = await refresh()
       }
-      headers.authorization = `Bearer ${token}`
+
+      if (token) {
+        const {payload: {exp}} = jws.decode(token)
+        if (Date.now() >= exp * 1000) {
+          token = await refresh()
+        }
+        headers.authorization = `Bearer ${token}`
+      }
     }
 
     if (Object.keys(query).length) {

--- a/codegen/templates/method.js
+++ b/codegen/templates/method.js
@@ -13,6 +13,7 @@ async {{operationId}} (params = {}) {
   let path = `/v${version || 2}` + '{{&endpoint}}'
   let query = {}
   let body = {}
+  let security = {{security}}
 
   {{#parameters}}
 
@@ -36,5 +37,5 @@ async {{operationId}} (params = {}) {
 
   {{/parameters}}
 
-  return request({method, path, query, body})
+  return request({method, path, query, body, security})
 }

--- a/codegen/transform.js
+++ b/codegen/transform.js
@@ -11,13 +11,15 @@ module.exports = (definition) =>
           return {...config, name, required: required.includes(name), body: true}
         })
       }
+      const {security} = definition.paths[path][method]
       return {
         ...definition.paths[path][method],
         method,
         endpoint: path,
         parameters: parameters
           .map((config) => ({...config, type: config.schema.type, [config.in]: true}))
-          .concat(form)
+          .concat(form),
+        security: !!(security && security.find((obj) => Object.keys(obj)[0] === 'auth0')),
       }
     })
   )

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -14,8 +14,36 @@ externalDocs:
   url: https://docs.skycatch.com/v2.0.0/reference
   description: SkyAPI Documentation
 servers:
-  - url: https://api.skycatch.com/v2
-  - url: https://staging-gemba.skycatch.com/v2
+  - url: https://{environment}.skycatch.com/v2
+    variables:
+      environment:
+        description: The environment you are building the API for
+        enum:
+          - api         # prod
+          - staging-api # stage
+        default: api
+  - url: https://{tenant}.auth0.com/oauth/token
+    variables:
+      tenant:
+        description: The Auth0 tenant
+        enum:
+          - skycatch-development
+          - skycatch-staging
+          - skycatch-production
+        default: skycatch-development
+components:
+  securitySchemes:
+    auth0: # arbitrary name
+      name: auth0
+      type: oauth2
+      description: Used by organization apps
+      flows:
+        clientCredentials: # authorizationCode, implicit, password or clientCredentials)
+          tokenUrl: https://{tenant}.auth0.com/oauth/token
+          scopes: {}
+          # scopes:
+          #   read_pets: read your pets
+          #   write_pets: modify pets in your account
 paths:
   /datasets:
     post:

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -97,6 +97,20 @@ describe('client', () => {
     await skyapi.getProjections()
   })
 
+  it('do not add authorization header on missing security', async () => {
+    server.once('request', (req, res) => {
+      t.equal(req.headers.authorization, undefined)
+      t.equal(req.method, 'GET')
+      t.equal(req.url, '/v2/projections')
+      res.end(JSON.stringify({}))
+    })
+    const skyapi = SkyAPI({
+      origin,
+      token: token({exp: Math.floor((Date.now() + 5000) / 1000)}),
+    })
+    await skyapi.getProjections()
+  })
+
   it('append querystring to the URL', async () => {
     server.once('request', (req, res) => {
       t.equal(req.url, '/v2/projections?lon=1&lat=2')


### PR DESCRIPTION
I've added a security schema definition inside the main spec file. Now every lambda that uses bearer auth have to set:

```yaml
security:
  - auth0: []
```

or a list of scopes where applicable:

```yaml
security:
  - auth0:
    - create:dataset
    - read:dataset
```

otherwise an Authorization header won't be sent, even if the SDK was initialized with credentials.

The tests are currently failing because the datasets-post lambda needs to be updated with the above definition.